### PR TITLE
[FEAT] 공용 컴포넌트 Button 제작

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "medicine",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^0.575.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "zustand": "^5.0.10"
@@ -2908,6 +2909,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.575.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.575.0.tgz",
+      "integrity": "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lucide-react": "^0.575.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "zustand": "^5.0.10"

--- a/src/components/commons/Button.jsx
+++ b/src/components/commons/Button.jsx
@@ -1,3 +1,37 @@
-export default function Button() {
-  return;
+import '../../styles/button.css';
+
+export default function Button({
+  children,
+  variant = 'primary', // primary | secondary | accent | neutral | danger | subtle
+  size = 'md', // sm | md | lg
+  fullWidth = false,
+  outline = false,
+  ghost = false,
+  pill = false,
+  loading = false,
+  leftIcon,
+  rightIcon,
+  disabled = false,
+  ...props
+}) {
+  const classes = [
+    'btn',
+    `btn-${variant}`,
+    `btn-${size}`,
+    outline && 'btn-outline',
+    ghost && 'btn-ghost',
+    pill && 'btn-pill',
+    fullWidth && 'btn-full',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button className={classes} disabled={disabled || loading} {...props}>
+      {loading && <span className="btn-spinner" />}
+      {!loading && leftIcon && <span className="btn-icon">{leftIcon}</span>}
+      <span className="btn-text">{children}</span>
+      {!loading && rightIcon && <span className="btn-icon">{rightIcon}</span>}
+    </button>
+  );
 }

--- a/src/styles/button.css
+++ b/src/styles/button.css
@@ -1,0 +1,248 @@
+/* Base */
+.btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+
+  border-radius: 0.75rem;
+  cursor: pointer;
+}
+
+.btn:not(.btn-outline) {
+  border: none;
+}
+
+.btn:focus-visible {
+  outline: 3px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+/* Variant */
+.btn-primary {
+  background: var(--primary);
+  color: var(--primary-content);
+}
+.btn-primary:hover {
+  background: var(--primary-focus);
+}
+
+.btn-secondary {
+  background: var(--secondary);
+  color: var(--secondary-content);
+}
+.btn-secondary:hover {
+  background: var(--secondary-focus);
+}
+
+.btn-accent {
+  background: var(--accent);
+  color: var(--accent-content);
+}
+.btn-accent:hover {
+  background: var(--accent-focus);
+}
+
+.btn-neutral {
+  background: var(--neutral);
+  color: var(--neutral-content);
+}
+.btn-neutral:hover {
+  background: var(--neutral-focus);
+}
+
+.btn-danger {
+  background: var(--error);
+  color: var(--error-content);
+}
+.btn-danger:hover {
+  filter: brightness(0.9);
+}
+
+.btn-subtle {
+  background: var(--base-200);
+  color: var(--base-content);
+}
+.btn-subtle:hover {
+  background: var(--base-300);
+}
+
+/* Outline */
+.btn-outline {
+  background: transparent;
+  border: 2px solid transparent !important;
+}
+
+.btn-outline.btn-primary {
+  background: transparent;
+  color: var(--primary);
+  border-color: var(--primary) !important;
+}
+.btn-outline.btn-primary:hover {
+  background: var(--primary);
+  color: var(--primary-content);
+}
+
+.btn-outline.btn-secondary {
+  background: transparent;
+  color: var(--secondary);
+  border-color: var(--secondary) !important;
+}
+.btn-outline.btn-secondary:hover {
+  background: var(--secondary);
+  color: var(--secondary-content);
+}
+
+.btn-outline.btn-accent {
+  background: transparent;
+  color: var(--accent);
+  border-color: var(--accent) !important;
+}
+.btn-outline.btn-accent:hover {
+  background: var(--accent);
+  color: var(--accent-content);
+}
+
+.btn-outline.btn-neutral {
+  background: transparent;
+  color: var(--neutral);
+  border-color: var(--neutral) !important;
+}
+.btn-outline.btn-neutral:hover {
+  background: var(--neutral);
+  color: var(--neutral-content);
+}
+
+.btn-outline.btn-danger {
+  background: transparent;
+  color: var(--error);
+  border-color: var(--error) !important;
+}
+.btn-outline.btn-danger:hover {
+  background: var(--error);
+  color: var(--error-content);
+}
+
+.btn-outline.btn-subtle {
+  background: transparent;
+  color: var(--base-content);
+  border-color: var(--base-content) !important;
+}
+.btn-outline.btn-subtle:hover {
+  background: var(--base-content);
+  color: var(--base-200);
+}
+
+/* Ghost */
+.btn-ghost {
+  background: transparent;
+  box-shadow: none;
+}
+.btn-ghost.btn-primary,
+.btn-ghost.btn-secondary,
+.btn-ghost.btn-accent,
+.btn-ghost.btn-neutral,
+.btn-ghost.btn-danger,
+.btn-ghost.btn-subtle {
+  background: transparent;
+}
+
+.btn-ghost.btn-primary {
+  color: var(--primary);
+}
+.btn-ghost.btn-secondary {
+  color: var(--secondary);
+}
+.btn-ghost.btn-accent {
+  color: var(--accent);
+}
+.btn-ghost.btn-neutral {
+  color: var(--neutral);
+}
+.btn-ghost.btn-danger {
+  color: var(--error);
+}
+.btn-ghost.btn-subtle {
+  color: var(--base-content);
+}
+
+.btn-ghost.btn-primary:hover {
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+}
+.btn-ghost.btn-secondary:hover {
+  background: color-mix(in srgb, var(--secondary) 12%, transparent);
+}
+.btn-ghost.btn-accent:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.btn-ghost.btn-neutral:hover {
+  background: color-mix(in srgb, var(--neutral) 12%, transparent);
+}
+.btn-ghost.btn-danger:hover {
+  background: color-mix(in srgb, var(--error) 12%, transparent);
+}
+.btn-ghost.btn-subtle:hover {
+  background: var(--base-200);
+}
+
+/* Size */
+.btn-sm {
+  padding: 0.5rem 1rem !important;
+  font-size: 0.875rem !important;
+}
+
+.btn-md {
+  padding: 0.75rem 1.5rem !important;
+  font-size: 1rem !important;
+}
+
+.btn-lg {
+  padding: 1rem 2rem !important;
+  font-size: 1.125rem !important;
+}
+
+/* Pill */
+.btn-pill {
+  border-radius: 9999px !important;
+}
+
+/* Spinner */
+.btn-spinner {
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: btn-spin 0.6s linear infinite;
+}
+
+@keyframes btn-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Full width */
+.btn-full {
+  width: 100%;
+}

--- a/src/tests/ButtonTest.jsx
+++ b/src/tests/ButtonTest.jsx
@@ -1,0 +1,226 @@
+import { Search, Plus, Trash2, ArrowRight, Download } from 'lucide-react';
+import Button from '../components/commons/Button';
+
+export default function ButtonTest() {
+  return (
+    <div
+      style={{
+        padding: '2rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '2rem',
+      }}
+    >
+      {/* Variant */}
+      <section>
+        <h3>Variant</h3>
+        <div
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            flexWrap: 'wrap',
+            marginTop: '0.75rem',
+          }}
+        >
+          <Button variant="primary">Primary</Button>
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="accent">Accent</Button>
+          <Button variant="neutral">Neutral</Button>
+          <Button variant="danger">Danger</Button>
+          <Button variant="subtle">Subtle</Button>
+        </div>
+      </section>
+
+      {/* Outline */}
+      <section>
+        <h3>Outline</h3>
+        <div
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            flexWrap: 'wrap',
+            marginTop: '0.75rem',
+          }}
+        >
+          <Button variant="primary" outline>
+            Primary
+          </Button>
+          <Button variant="secondary" outline>
+            Secondary
+          </Button>
+          <Button variant="accent" outline>
+            Accent
+          </Button>
+          <Button variant="neutral" outline>
+            Neutral
+          </Button>
+          <Button variant="danger" outline>
+            Danger
+          </Button>
+          <Button variant="subtle" outline>
+            Subtle
+          </Button>
+        </div>
+      </section>
+
+      {/* Ghost */}
+      <section>
+        <h3>Ghost</h3>
+        <div
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            flexWrap: 'wrap',
+            marginTop: '0.75rem',
+          }}
+        >
+          <Button variant="primary" ghost>
+            Primary
+          </Button>
+          <Button variant="secondary" ghost>
+            Secondary
+          </Button>
+          <Button variant="accent" ghost>
+            Accent
+          </Button>
+          <Button variant="neutral" ghost>
+            Neutral
+          </Button>
+          <Button variant="danger" ghost>
+            Danger
+          </Button>
+          <Button variant="subtle" ghost>
+            Subtle
+          </Button>
+        </div>
+      </section>
+
+      {/* Size */}
+      <section>
+        <h3>Size</h3>
+        <div
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            marginTop: '0.75rem',
+          }}
+        >
+          <Button size="sm">Small</Button>
+          <Button size="md">Medium</Button>
+          <Button size="lg">Large</Button>
+        </div>
+      </section>
+
+      {/* Pill */}
+      <section>
+        <h3>Pill</h3>
+        <div
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            flexWrap: 'wrap',
+            marginTop: '0.75rem',
+          }}
+        >
+          <Button pill>Primary</Button>
+          <Button variant="secondary" pill>
+            Secondary
+          </Button>
+          <Button variant="accent" outline pill>
+            Outline
+          </Button>
+        </div>
+      </section>
+
+      {/* Icon */}
+      <section>
+        <h3>Icon</h3>
+        <div
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            flexWrap: 'wrap',
+            marginTop: '0.75rem',
+          }}
+        >
+          <Button leftIcon={<Search size={16} />}>검색</Button>
+          <Button variant="accent" rightIcon={<ArrowRight size={16} />}>
+            다음
+          </Button>
+          <Button variant="secondary" leftIcon={<Download size={16} />}>
+            다운로드
+          </Button>
+          <Button variant="danger" leftIcon={<Trash2 size={16} />}>
+            삭제
+          </Button>
+          <Button variant="neutral" outline leftIcon={<Plus size={16} />}>
+            추가
+          </Button>
+        </div>
+      </section>
+
+      {/* Loading */}
+      <section>
+        <h3>Loading</h3>
+        <div
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            flexWrap: 'wrap',
+            marginTop: '0.75rem',
+          }}
+        >
+          <Button loading>저장 중...</Button>
+          <Button variant="secondary" loading>
+            불러오는 중...
+          </Button>
+          <Button variant="danger" outline loading>
+            삭제 중...
+          </Button>
+        </div>
+      </section>
+
+      {/* Disabled */}
+      <section>
+        <h3>Disabled</h3>
+        <div
+          style={{
+            display: 'flex',
+            gap: '0.75rem',
+            flexWrap: 'wrap',
+            marginTop: '0.75rem',
+          }}
+        >
+          <Button disabled>Primary</Button>
+          <Button variant="secondary" disabled>
+            Secondary
+          </Button>
+          <Button variant="accent" outline disabled>
+            Outline
+          </Button>
+        </div>
+      </section>
+
+      {/* Full Width */}
+      <section>
+        <h3>Full Width</h3>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.75rem',
+            marginTop: '0.75rem',
+            maxWidth: '400px',
+          }}
+        >
+          <Button fullWidth>Full Width Primary</Button>
+          <Button variant="secondary" outline fullWidth>
+            Full Width Outline
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 작업 내용
- Button 컴포넌트 제작
- ButtonTest 페이지 제작
- 아이콘 라이브러리(lucide-react) 설치

## 🔥 변경 사항
- 아이콘 라이브러리(lucide-react) 설치했으니 pull한 후 `npm i` 한번 부탁드립니다.
- Button 컴포넌트와 ButtonTest 페이지를 제작했습니다.

## 📷 스크린샷
<img width="747" height="1073" alt="image" src="https://github.com/user-attachments/assets/c267955a-8c87-4c9b-b390-4a2847e78b73" />

## 아이콘 라이브러리(lucide-react) 사용방법
```jsx
import { Check, X, Pill } from "lucide-react"; // 원하는 아이콘 import

export default function Example() {
  return (
    <div>
      <Check size={20} />
      <X size={20} color="red" />
      <Pill size={24} strokeWidth={1.5} />
    </div>
  );
}
```
[Lucide 공식 사이트 바로가기](https://lucide.dev/)

closes #5 