### PR TITLE
[FEAT] CheckIn 페이지 UI Figma 기준 수정 (#24)

### DIFF
--- a/src/components/CheckIn/Caution.jsx
+++ b/src/components/CheckIn/Caution.jsx
@@ -1,9 +1,13 @@
+import { AlertCircle } from 'lucide-react';
+
 export default function Caution() {
   return (
-    <div className="card bg-base-100 shadow-sm border border-base-300">
-      <p className="text-small font-bold mb-2 text-Danger">📌 주의사항</p>
+    <div className="card-base">
+      <p className="font-bold flex items-center gap-1 mb-3">
+        <AlertCircle size={16} /> 주의사항
+      </p>
       <textarea
-        className="w-full h-32 bg-base-200 rounded-lg p-4 outline-none resize-none border border-base-300"
+        className="w-full h-32 bg-base-100 rounded-lg p-3 outline-none resize-none border border-base-300 focus:border-primary transition-colors"
         placeholder="내용을 입력해주세요"
       />
     </div>

--- a/src/components/CheckIn/CheckInActions.jsx
+++ b/src/components/CheckIn/CheckInActions.jsx
@@ -2,9 +2,13 @@ import Button from '../commons/Button';
 
 export default function CheckInActions() {
   return (
-    <div className="flex gap-3 justify-end pt-4">
-      <Button variant="primary">등록하기</Button>
-      <Button variant="neutral">취소</Button>
+    <div className="flex gap-2 justify-end pt-2">
+      <Button variant="primary" size="sm">
+        등록
+      </Button>
+      <Button variant="neutral" size="sm">
+        취소
+      </Button>
     </div>
   );
 }

--- a/src/components/CheckIn/DoseAmount.jsx
+++ b/src/components/CheckIn/DoseAmount.jsx
@@ -1,23 +1,26 @@
-import Button from '../commons/Button';
 import { Pill } from 'lucide-react';
 
-export default function DoseAmount({ selected, onChange }) {
+const DOSE_LABELS = ['아침', '점심', '저녁'];
+
+export default function DoseAmount({ doses, onToggle }) {
   return (
-    <div className="card bg-base-100 shadow-sm border border-base-300 flex flex-row justify-between items-center">
+    <div className="card-base flex flex-row justify-between items-center">
       <span className="font-bold flex items-center gap-1">
         <Pill size={16} /> 하루 복용량
       </span>
-      <div className="flex gap-3">
-        {[1, 2, 3].map((num) => (
-          <Button
-            pill
-            variant={selected === num ? 'primary' : 'subtle'}
-            size="sm"
-            key={num}
-            onClick={() => onChange(num)}
-          >
-            {num}
-          </Button>
+      <div className="flex items-center gap-2">
+        {DOSE_LABELS.map((label, i) => (
+          <div key={i} className="flex items-center gap-1">
+            <span className="text-p text-neutral">{label}</span>
+            <button
+              type="button"
+              onClick={() => onToggle(i)}
+              title={label}
+              className={`w-4 h-4 rounded-full cursor-pointer transition-colors ${
+                doses[i] ? 'bg-primary' : 'bg-base-300 hover:bg-primary/40'
+              }`}
+            />
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/CheckIn/DosePeriod.jsx
+++ b/src/components/CheckIn/DosePeriod.jsx
@@ -2,12 +2,14 @@ import { Calendar } from 'lucide-react';
 
 export default function DosePeriod() {
   return (
-    <div className="card bg-base-100 shadow-sm border border-base-300 flex flex-row justify-between items-center">
+    <div className="card-base flex flex-row justify-between items-center">
       <div className="flex items-center gap-2">
         <span className="font-bold flex items-center gap-1">
           <Calendar size={16} /> 복용 기간
         </span>
-        <small>2026.01.02.(금) ~ 2026.01.16.(금)</small>
+        <small className="text-base-content">
+          2026.01.02.(금) ~ 2026.01.16.(금)
+        </small>
       </div>
       <label className="flex items-center gap-2 cursor-pointer">
         <small>기록</small>

--- a/src/components/CheckIn/MedicineInput.jsx
+++ b/src/components/CheckIn/MedicineInput.jsx
@@ -1,22 +1,26 @@
-import Button from '../commons/Button';
-import { NotebookPen } from 'lucide-react';
+import { X } from 'lucide-react';
 
-export default function MedicineInput({ num, placeholder }) {
+export default function MedicineInput({ num, placeholder, onDelete, deletable = true }) {
   return (
-    <div className="flex gap-2 mb-3 items-center">
-      <div className="flex-1 relative">
-        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-neutral font-medium">
-          {num}. 약 이름:
-        </span>
-        <input
-          type="text"
-          placeholder={placeholder}
-          className="input pl-20 bg-base-100 border-base-300 text-base-content"
-        />
-      </div>
-      <Button variant="primary" pill>
-        <NotebookPen size={16} />
-      </Button>
+    <div className="relative">
+      <span className="absolute left-4 top-1/2 -translate-y-1/2 text-small text-neutral whitespace-nowrap">
+        {num}. 약 이름
+      </span>
+      <input
+        type="text"
+        placeholder={placeholder}
+        className="w-full pl-22 pr-10 py-2.5 bg-base-100 border border-base-300 rounded-lg outline-none focus:border-primary transition-colors"
+      />
+      {deletable && (
+        <button
+          type="button"
+          onClick={onDelete}
+          title="삭제"
+          className="absolute right-3 top-1/2 -translate-y-1/2 w-6 h-6 flex items-center justify-center text-neutral hover:text-primary cursor-pointer"
+        >
+          <X size={16} />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/CheckIn/MedicineList.jsx
+++ b/src/components/CheckIn/MedicineList.jsx
@@ -1,22 +1,42 @@
 import { useState } from 'react';
-import Button from '../commons/Button';
+import { Plus } from 'lucide-react';
 import MedicineInput from './MedicineInput';
 
 export default function MedicineList() {
   const [medicines, setMedicines] = useState([1]);
 
   const handleAdd = () => {
-    setMedicines((prev) => [...prev, prev.length + 1]);
+    setMedicines((prev) => [...prev, prev.length ? prev[prev.length - 1] + 1 : 1]);
+  };
+
+  const handleDelete = (id) => {
+    setMedicines((prev) => prev.filter((n) => n !== id));
   };
 
   return (
-    <div className="card bg-base-100 shadow-sm border border-base-300">
-      {medicines.map((num) => (
-        <MedicineInput key={num} num={num} placeholder="" />
-      ))}
-      <Button variant="primary" outline fullWidth onClick={handleAdd}>
-        + 추가하기
-      </Button>
+    <div className="card-base">
+      <p className="font-bold flex items-center gap-1 mb-3">
+        <Plus size={16} /> 약 추가
+      </p>
+      <div className="space-y-2">
+        {medicines.map((num, i) => (
+          <MedicineInput
+            key={num}
+            num={i + 1}
+            placeholder=""
+            deletable={medicines.length > 1}
+            onDelete={() => handleDelete(num)}
+          />
+        ))}
+        <button
+          type="button"
+          onClick={handleAdd}
+          title="약 추가"
+          className="w-full py-2.5 bg-base-100 border border-base-300 rounded-lg outline-none hover:border-primary text-neutral hover:text-primary cursor-pointer transition-colors flex items-center justify-center"
+        >
+          <Plus size={18} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/CheckIn/TitleInput.jsx
+++ b/src/components/CheckIn/TitleInput.jsx
@@ -1,10 +1,10 @@
 export default function TitleInput() {
   return (
-    <div className="card bg-base-100 shadow-sm border border-base-300 flex flex-row items-center gap-2">
+    <div className="card-base flex flex-row items-center gap-2">
       <p className="font-bold whitespace-nowrap">제목:</p>
       <input
         type="text"
-        placeholder="ex)감기약"
+        placeholder="ex) 감기약"
         className="w-full bg-transparent outline-none"
       />
     </div>

--- a/src/pages/CheckIn.jsx
+++ b/src/pages/CheckIn.jsx
@@ -7,13 +7,17 @@ import Caution from '../components/CheckIn/Caution';
 import CheckInActions from '../components/CheckIn/CheckInActions';
 
 export default function CheckIn() {
-  const [dose, setDose] = useState(1);
+  const [doses, setDoses] = useState([false, false, false]);
+
+  const handleToggleDose = (i) => {
+    setDoses((prev) => prev.map((v, idx) => (idx === i ? !v : v)));
+  };
 
   return (
     <div className="space-y-4">
       <TitleInput />
       <DosePeriod />
-      <DoseAmount selected={dose} onChange={setDose} />
+      <DoseAmount doses={doses} onToggle={handleToggleDose} />
       <MedicineList />
       <Caution />
       <CheckInActions />


### PR DESCRIPTION
## 📌 작업 내용
Figma 디자인 기준으로 CheckIn 페이지 컴포넌트들의 스타일/구조 정리.

## 🔥 변경 사항
### `design: CheckIn 카드 스타일 card-base 적용 및 라벨 정리`
- `TitleInput`: 인라인 카드 스타일 → `card-base` 유틸리티, placeholder `예) 감기약` → `ex) 감기약`
- `DosePeriod`: `card-base` 적용, 날짜 텍스트 `text-base-content`로 검은색 처리, "기록일" 텍스트 → "기록" + `check-base` 체크박스
- `Caution`: `card-base` 적용, 📌 이모지 → `AlertCircle` 아이콘, textarea 톤 정리
- `CheckInActions`: 등록하기/취소 → 등록/취소, size `sm`

### `feat: 하루 복용량 아침/점심/저녁 토글 도입`
- `DoseAmount`: 1/2/3 숫자 버튼 → 아침/점심/저녁 토글 도트(`bg-primary` ↔ `bg-base-300`)
- 라벨-도트 간격 `gap-1`, 묶음 사이 `gap-2`
- `CheckIn.jsx`: state `dose: number` → `doses: [bool, bool, bool]`, `handleToggleDose` 추가

### `design: 약 추가 리스트 박스 형태 정리`
- `MedicineInput`: 라벨 `1. 약 이름:` → `1. 약 이름`, `NotebookPen` 버튼 → 인풋 박스 내부 우측 `X` 삭제 버튼(absolute), 1개일 때 X 숨김
- `MedicineList`: "약 추가" 헤더 추가, 풀폭 추가 버튼 → 인풋과 동일한 박스 형태의 + 버튼

## 비고
- 복용량 데이터 모델 변경(`number → bool[]`)은 Meds 페이지의 `doses` 구조와 일치시킴 (향후 통합 대비)

## 📷 스크린샷
<img width="1076" height="956" alt="스크린샷 2026-05-31 오후 7 11 39" src="https://github.com/user-attachments/assets/2cf01507-c5af-4240-8707-5a5aaf8ece2f" />

closes #24